### PR TITLE
Update 01-messages-and-path-names.md

### DIFF
--- a/01-messages-and-path-names.md
+++ b/01-messages-and-path-names.md
@@ -438,7 +438,8 @@ Mandatory
                }
               param_settings {
                  param: 'NotifType'
-                 value: 'ValueChange'}
+                 value: 'ValueChange'
+               }
               param_settings {
                  param: 'ReferenceList'
                  value: 'Device.LocalAgent.EndpointID'
@@ -477,21 +478,21 @@ Mandatory
 6.  Clean-up: Send a Delete message to the EUT with the following
     structure:
 
-  ```{filter=pbv type=Msg}
-  header {
-    msg_id: '<msg_id>'
-    msg_type: DELETE
-    }
-    body {
-      request {
-        delete {
-          allow_partial: false
-          obj_paths: 'Device.LocalAgent.Subscription.<instance identifier 1>.'
-          obj_paths: 'Device.LocalAgent.Subscription.<instance identifier 2>.'
+      ```{filter=pbv type=Msg}
+      header {
+      msg_id: '<msg_id>'
+      msg_type: DELETE
+      }
+      body {
+        request {
+          delete {
+            allow_partial: false
+            obj_paths: 'Device.LocalAgent.Subscription.<instance identifier 1>.'
+            obj_paths: 'Device.LocalAgent.Subscription.<instance identifier 2>.'
+          }
         }
       }
-    }
-  ```
+      ```
 
 7.  Allow the EUT to send a DeleteResp.
 


### PR DESCRIPTION
1.5 Add message with allow partial false, multiple objects 
1) Test Procedure - step 1: Fix line break
2) Test Procedure - step 6: Fix code indentation - it makes new ordered list instead of continue previous one in web-version (https://usp-test.broadband-forum.org/02-index-messages-and-path-names.html#sec:add-message-with-allow-partial-false-multiple-objects)