### PR TITLE
Fix 1.29 test's metrics

### DIFF
--- a/01-messages-and-path-names.md
+++ b/01-messages-and-path-names.md
@@ -2329,7 +2329,7 @@ structure:
 
 ### Test Metrics
 
-1. The EUT sends a DeleteResponse containing an empty oper_success element (i.e., `oper_success{}`).
+1. The EUT sends a DeleteResp containing an empty oper_success element.
 
 ## 1.30 Delete message with allow partial true, invalid object
 


### PR DESCRIPTION
1. According to usp-msg-1-2 specification (https://github.com/BroadbandForum/usp/blob/master/specification/usp-msg-1-2.proto#L126) the response must be DeleteResp instead of DeleteResponse.
2. To be uniform - put a description similar to 1.25 test's metrics.